### PR TITLE
Update docs and add getValue/setValue

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,2 +1,2 @@
 var jsEdit = require('./')({ container: document.querySelector('#editor') })
-jsEdit.editor.setValue(document.querySelector('#program').text)
+jsEdit.setValue(document.querySelector('#program').text)

--- a/index.js
+++ b/index.js
@@ -115,3 +115,11 @@ Editor.prototype.addDropHandler = function () {
   }, false )
   
 }
+
+Editor.prototype.getValue = function() {
+  return this.editor.getValue()
+}
+
+Editor.prototype.setValue = function(value) {
+  return this.editor.setValue(value)
+}

--- a/readme.md
+++ b/readme.md
@@ -20,9 +20,9 @@ npm install javascript-editor
 ```
 
 ```javascript
-var editor = require('javascript-editor')
+var createEditor = require('javascript-editor')
 
-editor({ container: document.querySelector('#editor') })
+var editor = createEditor({ container: document.querySelector('#editor') })
 
 editor.on('change', function() {
   var value = editor.getValue()


### PR DESCRIPTION
Hey! I'm using this for the craft demo: http://shama.github.io/craft/ I noticed a typo in the docs but when updating, I figured adding `getValue/setValue` to `Editor` would be a little more intuitive. Rather than having to do `editor.editor.getValue()`.

Thanks!
