### PR TITLE
fix weird scroll bug

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,3 +13,5 @@ body > pre { display: none }
 @media all and (max-width: 800px) { .CodeMirror { font-size: 14px !important; } }
 
 #editor .CodeMirror .errorLine { background: rgba(255,0,0,0.25); }
+
+.CodeMirror-scroll { overflow: auto; }


### PR DESCRIPTION
Overriding .Codemirror-scroll to overflow: auto fixes the weird choppy scrolling mentioned in this requirebin issue: https://github.com/maxogden/requirebin/issues/10

Tested on Mac with Chrome and Firefox.

Found the fix by updating/digging through the latest codemirror.css, but updating the whole file also introduces other weird formatting issues, so I figure this little override is probably good for now.
