### PR TITLE
allow futher processing on the AST

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,2 +1,7 @@
 var jsEdit = require('./')({ container: document.querySelector('#editor') })
 jsEdit.setValue(document.querySelector('#program').text)
+
+jsEdit.on('valid', function(valid, ast) {
+  console.log(valid)
+  console.log(ast)
+})

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ inherits(Editor, events.EventEmitter)
 
 Editor.prototype.update = function() {
   var hasErrors = this.validate(this.editor.getValue())
-  this.emit('valid', hasErrors)
+  this.emit('valid', hasErrors, this.ast)
   return hasErrors
 }
 
@@ -69,7 +69,9 @@ Editor.prototype.validate = function(value) {
   }
   
   try {
-    var result = esprima.parse( value, { tolerant: true, loc: true } ).errors
+    this.ast = esprima.parse( value, { tolerant: true, loc: true } );
+    var result = this.ast.errors
+
     for ( var i = 0; i < result.length; i ++ ) {
       var error = result[ i ]
       var lineNumber = error.lineNumber - 1


### PR DESCRIPTION
Instead of throwing away the esprima parse results, let's use allow the to be used by the caller.
